### PR TITLE
[AJPHR-281] Fix: restricted the sizeVariants choice in the avatar types and story…

### DIFF
--- a/src/design-system/avatar/avatar.stories.tsx
+++ b/src/design-system/avatar/avatar.stories.tsx
@@ -23,4 +23,5 @@ const Template: Story<AvatarProps> = (args) => {
 export const SelectCardStory = Template.bind({});
 SelectCardStory.args = {
   src: 'src/design-system/avatar/User-Photo.png',
+  sizeVariant: 'small',
 };

--- a/src/design-system/avatar/types.ts
+++ b/src/design-system/avatar/types.ts
@@ -2,5 +2,5 @@ import { ImgHTMLAttributes } from 'react';
 
 export type AvatarProps = {
   src: string;
-  sizeVariant?: string;
+  sizeVariant?: 'large' | 'small';
 } & ImgHTMLAttributes<HTMLImageElement>;


### PR DESCRIPTION
Fix: restricted the sizeVariant`s choice in the avatar types and storybook
Jira`s Link: https://ambush-journey.atlassian.net/browse/AJPHR-281
## Briefing
Ticket: https://ambush-journey.atlassian.net/browse/AJPHR-268

Restricted the sizeVariant`s choice in the avatar types and storybook"
## Achievements
- Only 2 options of size are displayed.

CC: @MarcelloAragoni, @Santos1000, @MedeirosKalluh 

## Screenshot

<img width="1147" alt="Screen Shot 2023-03-09 at 11 40 34" src="https://user-images.githubusercontent.com/91208001/224058834-2ed5268c-d981-44f4-be49-418872f994b8.png">
